### PR TITLE
Updated readme metadata to fix bug with publishing to Microsoft Learn…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ languages:
 - csharp
 - nodejs
 - javascript
+- data-api-builder
 products:
 - azure
 - static-web-apps

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ products:
 - azure
 - static-web-apps
 - azure-sql-database
-- data-api-builder
 urlFragment: sample
 name: Jamstack Todo App with Azure Static Web Apps, Data API builder, and Azure SQL Database
 description: This app creates a backend REST API with the Data API builder, uses Easy Auth configured with GitHub, authorizes data access using Data API builder prolicies, and hosts Data API builder in Azure Static Web Apps using "database connections."


### PR DESCRIPTION
- [x] Modifies #3

There's a bug with publishing where `data-api-builder` is not a valid value for `products`. It's a valid value for `languages` instead.

<https://github.com/MicrosoftDocs/samples/blob/main/Azure-Samples/dab-swa-todo/.samples-status.json#L10>